### PR TITLE
fix bower.json for bower auto-loading

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "ng-readingtime",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/jiin/ng-readingtime",
   "authors": [
     "Jiin <neri.barnini@gmail.com>"
   ],
   "description": "angular directive to calculate text reading time",
-  "main": "readingtime",
+  "main": "dist/ng-readingtime.min.js",
   "keywords": [
     "reading",
     "time",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-readingtime",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "angular directive to calculate text reading time",
   "main": "readingtime.js",
   "devDependencies": {


### PR DESCRIPTION
bower.json's MAIN file should be specified as the dist minified file.

This helps with plugins that use bower-main-files to auto-inject bower files into html.

also, inc version
